### PR TITLE
Yosegi-46 jackson and jetty security alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Upgraded for security alert.
Competed with Arrow in Hive's security alert support.

### How did you do the test? (Not required for updating documents)
The version has been upgraded, but there is no problem with compilation and unit testing.

